### PR TITLE
Ensure localdisk storage returns a path

### DIFF
--- a/utils/storage/localdisk.py
+++ b/utils/storage/localdisk.py
@@ -21,7 +21,7 @@ def write(data, dest, uuid):
     with open('/tmp/uploads/' + dest + '/' + uuid, 'w') as f:
         f.write(data)
         url = f
-    return url
+    return url.name
 
 
 def ls(src, uuid):


### PR DESCRIPTION
Without this, the URL field is a TextIOWrapper. Therefore, the moment
we try to upload anything, it fails - json.dumps in 'def produce' can't
turn that kind of object into a JSON.

Here's how the hash looks like:
```
upload-service_1  | ERROR:tornado.application:{'principal':
  'default_principal', 'rh_account': '000001', 'hash':
    '74d74f211ab04e8db62180ee866632d5', 'url': <_io.TextIOWrapper
    name='/tmp/uploads/insights-upload-quarantine/74d74f211ab04e8'
    mode='w' enco    ding='UTF-8'>, 'validation': 1, 'size': 3882,
    'service': 'testareno'}

TypeError: Object of type 'TextIOWrapper' is not JSON serializable
```

You'll need to substitute https://github.com/RedHatInsights/insights-upload/blob/master/app.py#L15 by `from utils.storage import localdisk as storage`
