### PR TITLE
Fix WORKDIR variable for localdisk

### DIFF
--- a/utils/storage/localdisk.py
+++ b/utils/storage/localdisk.py
@@ -30,6 +30,6 @@ def ls(src, uuid):
 
 
 def copy(src, dest, uuid):
-    os.rename(os.path.join(WORKDIR, src, uuid,
-              WORKDIR, dest, uuid))
+    os.rename(os.path.join(WORKDIR, src, uuid),
+              os.path.join(WORKDIR, dest, uuid))
     return os.path.join(WORKDIR, dest, uuid)


### PR DESCRIPTION
Fixes #12

- Use WORKDIR variable throughout and replace string concatenation
  with os.path.join