### PR TITLE
Fix double encoded json

### DIFF
--- a/app.py
+++ b/app.py
@@ -147,7 +147,7 @@ async def producer():
                 len(produce_queue), topic, msg
             )
             try:
-                await mqp.produce(topic, json.dumps(msg))
+                await mqp.produce(topic, msg)
                 logger.info("Produced on topic %s: %s", topic, msg)
             except exc.NoBrokersError:
                 logger.error('Produce Failed: No Brokers Available')

--- a/docker/consumer/app.py
+++ b/docker/consumer/app.py
@@ -49,7 +49,7 @@ while True:
 
     logger.info('Received message: {}'.format(msg.value().decode('utf-8')))
 
-    result = json.loads(json.loads(msg.value().decode('utf-8')))
+    result = json.loads(msg.value().decode('utf-8'))
 
     validation = {
         'hash': result['hash'],


### PR DESCRIPTION
Fixes #22 

kiel encodes messages to json by default so we do
not have to do it manually.