### PR TITLE
Allow running on bare metal without Docker

### DIFF
--- a/create_topics.py
+++ b/create_topics.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+from os import getenv
+from subprocess import check_call
+
+TOPICS = ["advisor",
+          "available",
+          "testareno",
+          "uploadvalidation"]
+
+zookeeper = getenv("ZOOKEEPER", "zookeeper:32181")
+
+for topic in TOPICS:
+    check_call(["kafka-topics",
+                "--create",
+                "--if-not-exists",
+                "--topic={}".format(topic),
+                "--partitions=1",
+                "--replication-factor=1",
+                "--zookeeper={}".format(zookeeper)])

--- a/docker/consumer/app.py
+++ b/docker/consumer/app.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 
 from time import sleep
 from confluent_kafka import Consumer, Producer, KafkaError
@@ -10,8 +11,10 @@ logger = logging.getLogger('test-consumer')
 
 logger.info('connecting...')
 
+MQ = os.getenv('KAFKAMQ', 'kafka:29092')
+
 c = Consumer({
-    'bootstrap.servers': 'kafka:29092',
+    'bootstrap.servers': MQ,
     'group.id': 'testgroup',
     'default.topic.config': {
         'auto.offset.reset': 'smallest'
@@ -20,7 +23,7 @@ c = Consumer({
 
 c.subscribe(['testareno'])
 
-p = Producer({'bootstrap.servers': 'kafka:29092'})
+p = Producer({'bootstrap.servers': MQ})
 
 
 def delivery_report(err, msg):


### PR DESCRIPTION
The upload service can perfectly run without using the docker-compose spec, even without Docker at all. It can use an existing Kafka instance.

The same applies to the test consumer app. Added a possibility to override the Kafka host by an environment variable, just as the upload service itself does.

Added information to README. Created a simple script that creates topics in Kafka, just as the startup script does.

cc @kylape 