### PR TITLE
Mention Kafka CLI utilities in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ You should see messages in the docker logs where the upload-service sends a mess
 the consumer picks it up, returns a failure message, then the upload-service sends it to
 the permanent bucket.
 
+For debugging purposes it’s also possible to produce/consume Kafka messages with its own CLI tools.
+
+    sudo docker-compose exec kafka kafka-console-consumer --topic=testareno --bootstrap-server=localhost:29092
+    sudo docker-compose exec kafka kafka-console-producer --topic=testareno --broker-list=localhost:29092
+
 To see the docker-compose logs:
 
     sudo docker-compose logs -f


### PR DESCRIPTION
There are native Kafka command-line [utilities](https://kafka.apache.org/quickstart) to consume and produce plaintext messages. These can help development and debugging and can be run in Docker [container](https://github.com/RedHatInsights/insights-upload/blob/cfb1c30abb17f62b5a2ac23ebbc1458c8bfbfba8/docker/docker-compose.yml#L8). Added guide how to launch them to [README](
https://github.com/RedHatInsights/insights-upload/compare/master...Glutexo:kafka_cli_utils?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8).

If #28 would get merged before this, then it’d be necessary to add bare-metal instructions too.