### PR TITLE
Describe usage of Kafka CLI without Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,16 @@ You should see messages in the docker logs where the upload-service sends a mess
 the consumer picks it up, returns a failure message, then the upload-service sends it to
 the permanent bucket.
 
-For debugging purposes it’s also possible to produce/consume Kafka messages with its own CLI tools.
+For debugging purposes it’s also possible to produce/consume Kafka messages with its
+own CLI tools. Run those using the following commands if you’re using Docker:
 
     sudo docker-compose exec kafka kafka-console-consumer --topic=testareno --bootstrap-server=localhost:29092
     sudo docker-compose exec kafka kafka-console-producer --topic=testareno --broker-list=localhost:29092
+
+Otherwise if you’re running on bare metal, use these commands:
+
+    kafka-console-consumer --topic=testareno --bootstrap-server=localhost:9092
+    kafka-console-producer --topic=testareno --broker-list=localhost:9092
 
 To see the docker-compose logs:
 


### PR DESCRIPTION
There are both Docker and bare metal options of running the app described. Running Kafka command-line tools was described only for the Docker variant though. Added [commands](https://github.com/RedHatInsights/insights-upload/compare/master...Glutexo:kafka_cli_without_docker?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R167) for non-docker environment.

Because #28 was merged first, #30 did not contain the necessary amendments.