### PR TITLE
Change identity default value to None

### DIFF
--- a/app.py
+++ b/app.py
@@ -365,7 +365,7 @@ class UploadHandler(tornado.web.RequestHandler):
         Validate upload, get service name, create UUID, save to local storage,
         then offload for async processing
         """
-        identity = False
+        identity = None
         if not self.request.files.get('upload'):
             logger.info('Upload field not found')
             self.set_status(415, "Upload field not found")

--- a/tests/app/test_upload_handler.py
+++ b/tests/app/test_upload_handler.py
@@ -5,10 +5,27 @@ from tempfile import NamedTemporaryFile
 from tornado.testing import AsyncHTTPTestCase, gen_test
 
 
-class TestUpload(AsyncHTTPTestCase):
-    localdisk = import_module("utils.storage.localdisk")
+localdisk = import_module("utils.storage.localdisk")
 
+
+async def process_upload(filename, size, tracking_id, hash_value, identity, service):
+    """
+    A dummy method to path the real process_upload method. It must be asynchronous, but (Magic)Mock doesn’t support
+    that.
+    """
+    pass
+
+
+class Anything(object):
+    def __eq__(self, other):
+        return True
+
+
+class TestUpload(AsyncHTTPTestCase):
     def get_app(self):
+        """
+        Get the tornado.web.Application instance.
+        """
         return app
 
     @patch("app.os.remove")
@@ -29,3 +46,27 @@ class TestUpload(AsyncHTTPTestCase):
         yield handler.upload("some filename", "some tracking id", "some hash value")
 
         logger.exception.assert_not_called()
+
+
+class TestPost(AsyncHTTPTestCase):
+
+    def get_app(self):
+        """
+        Get the tornado.web.Application instance.
+        """
+        return app
+
+    @patch("app.UploadHandler.process_upload", wraps=process_upload)  # Must be an async method.
+    @patch("app.UploadHandler.write_data", return_value="some_file.tgz")
+    @patch("app.UploadHandler.upload_validation", return_value=False)
+    @gen_test
+    def test_indentity_default_value(self, upload_validation, write_data, process_upload):
+        size = 123
+        request = Mock(**{"files": {"upload": [{"content_type": "application/vnd.redhat.testareno.something+tgz",
+                                                "body": ""}]},
+                          "headers": {"Content-Length": size}})
+        handler = UploadHandler(app, request)
+
+        yield handler.post()
+
+        process_upload.assert_called_once_with(Anything(), Anything(), Anything(), Anything(), None, Anything())


### PR DESCRIPTION
The [_identity_](https://github.com/RedHatInsights/insights-upload/compare/master...Glutexo:identity_variable_type?expand=1#diff-3f41e546893dc64b71aaacad12cad815L368) variable is not a boolean value, it’s either a dict or it’s empty. Changed False to None to improve the semantics a bit.

Created a test for that. It uses quite a lot of [patchings](https://github.com/RedHatInsights/insights-upload/pull/38/files#diff-7fed750963bc8ef528076ecd8ad6ae4fR59) and it’s generally quite complicated. A test is as complicated as the tested method, so I’d keep it there as a memento for a possible refactor. The [_post_](https://github.com/RedHatInsights/insights-upload/blob/eba2b04c73406f21f7fdbe5b0e978510bea06e5c/app.py#L362) method has already become quite long.