### PR TITLE
Add validating service to available message

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ services will not utilize that.
 
 Services should return a message with the UID and the validation message to the `uploadvalidation` topic:
 
-    {'hash': 'abcdef123456', 'validation': 'success'} # or 'validation': 'failure'
+    {'hash': 'abcdef123456', 'validation': 'success', 'validating_service': 'testareno'} # or 'validation': 'failure'
     
 Fields:
 
   - hash: Unique ID being addresed by validation message
-  - validation: Either succes or failure based on whether the payload passed validation or not
+  - validation: Either `success` or `failure` based on whether the payload passed validation or not
+  - validating_service: Respond with the name of ther service that did the validation. ex: advisor
 
 ### Current Active Topics
 

--- a/app.py
+++ b/app.py
@@ -188,6 +188,7 @@ async def handle_file(msgs):
 
         hash_ = data['hash']
         result = data['validation']
+        service = data.get('service')
 
         logger.info('processing message: %s - %s', hash_, result)
         if result.lower() == 'success':
@@ -198,7 +199,8 @@ async def handle_file(msgs):
             produce_queue.append(
                 {
                     'topic': 'available',
-                    'msg': {'url': url}
+                    'msg': {'url': url,
+                            'validating_service': service}
                 }
             )
         elif result.lower() == 'failure':

--- a/docker/consumer/app.py
+++ b/docker/consumer/app.py
@@ -56,7 +56,8 @@ while True:
 
     validation = {
         'hash': result['hash'],
-        'validation': 'failure'
+        'validation': 'failure',
+        'validating_service': 'testareno'
     }
 
     sleep(10)  # Mock file verification and validation

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -171,7 +171,7 @@ def produce_queue_mocked():
 
 @pytest.fixture
 def broker_stage_messages(s3_mocked, produce_queue_mocked):
-    def set_url(_file, service, avoid_produce_queue=False, validation='success'):
+    def set_url(_file, service, avoid_produce_queue=False, validation='success', validating_service='testareno'):
         file_name = uuid.uuid4().hex
 
         file_path, _ = s3_storage.write(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -186,8 +186,8 @@ class TestProducerAndConsumer:
 
     @staticmethod
     def _create_message_s3(_file, _stage_message, avoid_produce_queue=False, validation='success',
-                           topic='uploadvalidation'):
-        return _stage_message(_file, topic, avoid_produce_queue, validation)
+                           topic='uploadvalidation', validating_service='testareno'):
+        return _stage_message(_file, topic, avoid_produce_queue, validation, validating_service)
 
     @asyncio.coroutine
     async def coroutine_test(self, method, exc_message='Stopping the iteration'):
@@ -259,7 +259,7 @@ class TestProducerAndConsumer:
         with FakeMQ():
             for _ in range(total_messages):
                 message = self._create_message_s3(
-                    local_file, broker_stage_messages, avoid_produce_queue=True, topic=topic, validation='failure'
+                    local_file, broker_stage_messages, avoid_produce_queue=True, topic=topic, validation='failure', validating_service='testareno'
                 )
                 app.mqc.send_and_wait(topic, json.dumps(message).encode('utf-8'), True)
                 produced_messages.append(message)
@@ -296,7 +296,7 @@ class TestProducerAndConsumer:
         with FakeMQ():
             for _ in range(total_messages):
                 message = self._create_message_s3(
-                    local_file, broker_stage_messages, avoid_produce_queue=True, topic=topic, validation='unknown'
+                    local_file, broker_stage_messages, avoid_produce_queue=True, topic=topic, validation='unknown', validating_service='testareno'
                 )
                 app.mqc.send_and_wait(topic, json.dumps(message).encode('utf-8'), True)
                 produced_messages.append(message)


### PR DESCRIPTION
The service that validates the message should respond with a field
indicating its name so that other services can know who validated the
payload once it hits the available queue

Fixes #42