### PR TITLE
Update endpoints to handle 3scale change

### DIFF
--- a/app.py
+++ b/app.py
@@ -470,10 +470,10 @@ class StatusHandler(tornado.web.RequestHandler):
 
 
 endpoints = [
-    (r"/", RootHandler),
-    (r"/api/v1/version", VersionHandler),
-    (r"/api/v1/upload", UploadHandler),
-    (r"/api/v1/status", StatusHandler),
+    (r"/r/insights/platform/upload", RootHandler),
+    (r"/r/insights/platform/upload/api/v1/version", VersionHandler),
+    (r"/r/insights/platform/upload/api/v1/upload", UploadHandler),
+    (r"/r/insights/platform/upload/api/v1/status", StatusHandler),
 ]
 
 app = tornado.web.Application(endpoints, max_body_size=MAX_LENGTH)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -38,7 +38,7 @@ class TestStatusHandler(AsyncHTTPTestCase):
                 self.io_loop.spawn_callback(app.producer)
                 self.io_loop.spawn_callback(app.consumer)
 
-                response = yield self.http_client.fetch(self.get_url('/api/v1/status'), method='GET')
+                response = yield self.http_client.fetch(self.get_url('/r/insights/platform/upload/api/v1/status'), method='GET')
 
                 body = json.loads(response.body)
 
@@ -59,7 +59,7 @@ class TestStatusHandler(AsyncHTTPTestCase):
         with FakeMQ(is_down=True):
             with moto.mock_s3():
                 s3_storage.s3 = boto3.client('s3')
-                response = yield self.http_client.fetch(self.get_url('/api/v1/status'), method='GET')
+                response = yield self.http_client.fetch(self.get_url('/r/insights/platform/upload/api/v1/status'), method='GET')
 
                 body = json.loads(response.body)
 
@@ -84,7 +84,7 @@ class TestUploadHandler(AsyncHTTPTestCase):
 
         # Build HTTP Request so that Tornado can recognize and use the payload test
         request = requests.Request(
-            url="http://localhost:8888/api/v1/upload", data={},
+            url="http://localhost:8888/r/insights/platform/upload/api/v1/upload", data={},
             files={file_field_name: (file_name, io.BytesIO(os.urandom(file_size)), mime_type)} if file_name else None
         )
         request.headers["x-rh-insights-request-id"] = "test"
@@ -96,27 +96,27 @@ class TestUploadHandler(AsyncHTTPTestCase):
 
     @gen_test
     def test_root_get(self):
-        response = yield self.http_client.fetch(self.get_url('/'), method='GET')
+        response = yield self.http_client.fetch(self.get_url('/r/insights/platform/upload'), method='GET')
         self.assertEqual(response.code, 200)
         self.assertEqual(response.body, b'boop')
-        response = yield self.http_client.fetch(self.get_url('/'), method='OPTIONS')
+        response = yield self.http_client.fetch(self.get_url('/r/insights/platform/upload'), method='OPTIONS')
         self.assertEqual(response.headers['Allow'], 'GET, HEAD, OPTIONS')
 
     @gen_test
     def test_upload_get(self):
-        response = yield self.http_client.fetch(self.get_url('/api/v1/upload'), method='GET')
+        response = yield self.http_client.fetch(self.get_url('/r/insights/platform/upload/api/v1/upload'), method='GET')
         self.assertEqual(response.body, b"Accepted Content-Types: gzipped tarfile, zip file")
 
     @gen_test
     def test_upload_allowed_methods(self):
-        response = yield self.http_client.fetch(self.get_url('/api/v1/upload'), method='OPTIONS')
+        response = yield self.http_client.fetch(self.get_url('/r/insights/platform/upload/api/v1/upload'), method='OPTIONS')
         self.assertEqual(response.headers['Allow'], 'GET, POST, HEAD, OPTIONS')
 
     @gen_test
     def test_upload_post(self):
         request_context = self.prepare_request_context(100, 'payload.tar.gz')
         response = yield self.http_client.fetch(
-            self.get_url('/api/v1/upload'),
+            self.get_url('/r/insights/platform/upload/api/v1/upload'),
             method='POST',
             body=request_context.body,
             headers=request_context.headers
@@ -126,7 +126,7 @@ class TestUploadHandler(AsyncHTTPTestCase):
 
     @gen_test
     def test_version(self):
-        response = yield self.http_client.fetch(self.get_url('/api/v1/version'), method='GET')
+        response = yield self.http_client.fetch(self.get_url('/r/insights/platform/upload/api/v1/version'), method='GET')
         self.assertEqual(response.code, 200)
         self.assertEqual(response.body, b'{"version": "%s"}' % VERSION)
 
@@ -136,7 +136,7 @@ class TestUploadHandler(AsyncHTTPTestCase):
 
         with self.assertRaises(HTTPClientError) as response:
             yield self.http_client.fetch(
-                self.get_url('/api/v1/upload'),
+                self.get_url('/r/insights/platform/upload/api/v1/upload'),
                 method='POST',
                 body=request_context.body,
                 headers=request_context.headers
@@ -156,7 +156,7 @@ class TestUploadHandler(AsyncHTTPTestCase):
 
         with self.assertRaises(HTTPClientError) as response:
             yield self.http_client.fetch(
-                self.get_url('/api/v1/upload'),
+                self.get_url('/r/insights/platform/upload/api/v1/upload'),
                 method='POST',
                 body=request_context.body,
                 headers=request_context.headers
@@ -171,7 +171,7 @@ class TestUploadHandler(AsyncHTTPTestCase):
 
         with self.assertRaises(HTTPClientError) as response:
             yield self.http_client.fetch(
-                self.get_url('/api/v1/upload'),
+                self.get_url('/r/insights/platform/upload/api/v1/upload'),
                 method='POST',
                 body=request_context.body,
                 headers=request_context.headers


### PR DESCRIPTION
3Scale will soon be forwarding the full path rather than stripping
the insights/platform portion.

** Do not merge until 3Scale change is in place