### PR TITLE
Remove upload progress tracking

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,7 @@ def broker_stage_messages(s3_mocked, produce_queue_mocked):
     def set_url(_file, service, avoid_produce_queue=False, validation='success'):
         file_name = uuid.uuid4().hex
 
-        file_path, _ = s3_storage.write(
+        file_path = s3_storage.write(
             _file,
             s3_storage.QUARANTINE,
             file_name

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -183,7 +183,7 @@ class TestProducerAndConsumer:
         [self._create_message_s3(local_file, broker_stage_messages) for _ in range(total_messages)]
 
         with FakeMQ() as mq:
-            producer = app.MQClient(mq, "producer").run(app.send_to_preprocessors)
+            producer = app.MQClient(mq, "producer").run(app.make_preprocessor())
             assert app.mqp.produce_calls_count == 0
             assert len(app.produce_queue) == total_messages
 
@@ -310,7 +310,7 @@ class TestProducerAndConsumer:
         [self._create_message_s3(local_file, broker_stage_messages) for _ in range(total_messages)]
 
         with FakeMQ(connection_failing_attempt_countdown=1, disconnect_in_operation=2) as mq:
-            producer = app.MQClient(mq, "producer").run(app.send_to_preprocessors)
+            producer = app.MQClient(mq, "producer").run(app.make_preprocessor())
             assert app.mqp.produce_calls_count == 0
             assert len(app.produce_queue) == total_messages
 

--- a/utils/storage/localdisk.py
+++ b/utils/storage/localdisk.py
@@ -1,7 +1,4 @@
 import os
-from collections import namedtuple
-from time import time
-
 
 QUARANTINE = os.getenv('S3_QUARANTINE', 'insights-upload-quarantine')
 PERM = os.getenv('S3_PERM', 'insights-upload-perm-test')
@@ -11,8 +8,6 @@ dirs = [WORKDIR,
         os.path.join(WORKDIR, QUARANTINE),
         os.path.join(WORKDIR, PERM),
         os.path.join(WORKDIR, REJECT)]
-
-DummyCallback = namedtuple("DummyCallback", ["percentage", "time_last_updated"])
 
 
 def stage():
@@ -26,8 +21,7 @@ def write(data, dest, uuid):
     with open(os.path.join(WORKDIR, dest, uuid), 'w') as f:
         f.write(data)
         url = f
-    callback = DummyCallback(percentage=100, time_last_updated=time())
-    return url.name, callback
+    return url.name
 
 
 def ls(src, uuid):

--- a/utils/storage/s3.py
+++ b/utils/storage/s3.py
@@ -1,7 +1,5 @@
 import boto3
 import os
-import threading
-import time
 
 from botocore.exceptions import ClientError
 
@@ -18,30 +16,12 @@ s3 = boto3.client('s3',
                   aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
 
 
-class UploadProgress(object):
-    """Tracks progress of an uploading file."""
-    def __init__(self, filename):
-        self._filename = filename
-        self._size = float(os.path.getsize(filename))
-        self._seen_so_far = 0
-        self._lock = threading.Lock()
-        self.percentage = 0.0
-        self.time_last_updated = 0.0
-
-    def __call__(self, bytes_amount):
-        with self._lock:
-            self._seen_so_far += bytes_amount
-            self.time_last_updated = time.time()
-            self.percentage = (self._seen_so_far / self._size) * 100
-
-
 def write(data, dest, uuid):
-    callback = UploadProgress(data)
-    s3.upload_file(data, dest, uuid, Callback=callback)
+    s3.upload_file(data, dest, uuid)
     url = s3.generate_presigned_url('get_object',
                                     Params={'Bucket': dest,
                                             'Key': uuid}, ExpiresIn=100)
-    return url, callback
+    return url
 
 
 def copy(src, dest, uuid):


### PR DESCRIPTION
Upload timeouts are 60 seconds by default in boto3, if there is a timeout we
will handle it automatically in the coroutine.

Also tweaking queue handling for send_to_preprocessors in a way
that prevents a bad message from spoiling the queue forever.