### PR TITLE
Send advisor to pup

### DIFF
--- a/app.py
+++ b/app.py
@@ -335,6 +335,7 @@ class UploadHandler(tornado.web.RequestHandler):
         values['hash'] = self.payload_id  # provided for backward compatibility
         values['size'] = self.size
         values['service'] = self.service
+        values['b64_identity'] = self.b64_identity
         if self.metadata:
             values['metadata'] = json.loads(self.metadata)
 
@@ -409,6 +410,7 @@ class UploadHandler(tornado.web.RequestHandler):
                 logger.info('x-rh-identity: %s', base64.b64decode(self.request.headers['x-rh-identity']))
                 header = json.loads(base64.b64decode(self.request.headers['x-rh-identity']))
                 self.identity = header['identity']
+                self.b64_identity = self.request.headers['x-rh-identity']
             self.size = int(self.request.headers['Content-Length'])
             body = self.request.files['upload'][0]['body']
 

--- a/app.py
+++ b/app.py
@@ -211,6 +211,16 @@ async def handle_file(msgs):
                                 }
                     }
                 )
+                # TODO: Remove this once advisor stops listening to their queue
+                if data.get('service') == 'advisor':
+                    produce_queue.append(
+                        {
+                            'topic': 'platform.upload.advisor',
+                            'msg': {'url': url,
+                                    'payload_id': payload_id
+                                    }
+                        }
+                    )
             elif result.lower() == 'failure':
                 logger.info('%s rejected', payload_id)
                 url = await IOLoop.current().run_in_executor(

--- a/app.py
+++ b/app.py
@@ -64,6 +64,7 @@ DUMMY_VALUES = {
 }
 
 VALIDATION_QUEUE = os.getenv('VALIDATION_QUEUE', 'platform.upload.validation')
+PUP_QUEUE = os.getenv('PUP_QUEUE', 'platform.upload.advisor-pup')
 
 # Message Queue
 MQ = os.getenv('KAFKAMQ', 'kafka:29092').split(',')
@@ -326,7 +327,10 @@ class UploadHandler(tornado.web.RequestHandler):
         if url:
             values['url'] = url
 
-            produce_queue.append({'topic': 'platform.upload.' + self.service, 'msg': values})
+            if self.service == 'advisor':
+                produce_queue.append({'topic': PUP_QUEUE, 'msg': values})
+            else:
+                produce_queue.append({'topic': 'platform.upload.' + self.service, 'msg': values})
             logger.info(
                 "Data for payload_id [%s] put on produce queue (qsize: %d)",
                 self.payload_id, len(produce_queue)

--- a/app.py
+++ b/app.py
@@ -204,7 +204,9 @@ async def handle_file(msgs):
                 produce_queue.append(
                     {
                         'topic': 'platform.upload.available',
-                        'msg': {'url': url,
+                        'msg': {'id': data.get('id'),
+                                'url': url,
+                                'service': data.get('service'),
                                 'payload_id': payload_id
                                 }
                     }

--- a/utils/storage/s3.py
+++ b/utils/storage/s3.py
@@ -36,8 +36,7 @@ def copy(src, dest, uuid):
 
 
 def ls(src, uuid):
-    head_object = s3.head_object(Bucket=src, Key=uuid)
-    return head_object
+    return s3.head_object(Bucket=src, Key=uuid)
 
 
 def up_check(name):
@@ -45,8 +44,7 @@ def up_check(name):
     try:
         s3.head_bucket(Bucket=name)
     except ClientError as e:
-        error_code = int(e.response['Error']['Code'])
-        if error_code == 404:
+        if int(e.response['Error']['Code']) == 404:
             exists = False
 
     return exists


### PR DESCRIPTION
Start sending payloads to the advisor pup. 

Also added some handling in there to account for issues that may arise from advisor not being updated to handle some of this new stuff. 

  - don't try to copy S3 file if it's already been moved
  - Continue sending to the advisor topic after validation since they may not be filtering the available queue yet

Some random code cleanup I found while working this