### PR TITLE
Publish account/principal in 'available' topic message

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,7 @@ def broker_stage_messages(s3_mocked, produce_queue_mocked):
         )
 
         values = {
-            'rh_account': app.DUMMY_VALUES['rh_account'],
+            'account': app.DUMMY_VALUES['account'],
             'principal': app.DUMMY_VALUES['principal'],
             'validation': validation,
             'payload_id': file_name,


### PR DESCRIPTION
We'll continue to publish `rh_account` and `rh_principal` too just for backward compatibility

Related to https://github.com/RedHatInsights/insights-pup/pull/14