### PR TITLE
Valid topics config

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,13 +37,14 @@ else:
 logger = logging.getLogger('upload-service')
 
 # Valid topics config
-TOPIC_CONFIG = os.getenv('TOPIC_CONFIG', '/etc/upload-service/topics.json')
 VALID_TOPICS = []
+TOPIC_CONFIG = os.getenv('TOPIC_CONFIG', '/etc/upload-service/topics.json')
 with open(TOPIC_CONFIG, 'r') as f:
     topic_config = json.loads(f.read())
 
 for topic in topic_config:
-    VALID_TOPICS.append(topic['TOPIC_NAME'].split('.')[-1])
+    for name in topic['TOPIC_NAME'].split('.'):
+        VALID_TOPICS.append(name)
 
 # Set Storage driver to use
 storage_driver = os.getenv("STORAGE_DRIVER", "s3")

--- a/app.py
+++ b/app.py
@@ -6,7 +6,6 @@ import os
 import re
 import base64
 import sys
-import configparser
 
 from concurrent.futures import ThreadPoolExecutor
 from importlib import import_module
@@ -38,10 +37,13 @@ else:
 logger = logging.getLogger('upload-service')
 
 # Valid topics config
-TOPIC_CONFIG = os.getenv('TOPIC_CONFIG', '/etc/upload-service/topics.ini')
-config = configparser.ConfigParser()
-config.read(TOPIC_CONFIG)
-VALID_TOPICS = [topic.split('.')[-1] for topic in config['default']['topics'].splitlines()]
+TOPIC_CONFIG = os.getenv('TOPIC_CONFIG', '/etc/upload-service/topics.json')
+VALID_TOPICS = []
+with open(TOPIC_CONFIG, 'r') as f:
+    topic_config = json.loads(f.read())
+
+for topic in topic_config:
+    VALID_TOPICS.append(topic['TOPIC_NAME'].split('.')[-1])
 
 # Set Storage driver to use
 storage_driver = os.getenv("STORAGE_DRIVER", "s3")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,12 +18,18 @@ from tests.fixtures import StopLoopException
 
 
 def prepare_app():
-    file_path = "/tmp/topics.ini"
+    file_path = "/tmp/topics.json"
     body = """
-    [default]
-    topics =
-        platform.upload.advisor
-        platform.upload.testareno
+    [{
+       "TOPIC_NAME": "platform.upload.advisor",
+       "PARTITIONS": 3,
+       "REPLICAS": 3
+     },
+     {
+       "TOPIC_NAME": "platform.upload.testareno",
+       "PARTITIONS": 3,
+       "REPLICAS": 3
+    }]
     """
     try:
         sh.rm(file_path)
@@ -33,7 +39,7 @@ def prepare_app():
     with open(file_path, "w") as fp:
         fp.write(body)
 
-    os.environ['TOPIC_CONFIG'] = '/tmp/topics.ini'
+    os.environ['TOPIC_CONFIG'] = '/tmp/topics.json'
 
     import app
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,10 +11,36 @@ import responses
 import sh
 from moto import mock_s3
 
-import app
+
 from utils import mnm
 from utils.storage import localdisk as local_storage, s3 as s3_storage
 from tests.fixtures import StopLoopException
+
+
+def prepare_app():
+    file_path = "/tmp/topics.ini"
+    body = """
+    [default]
+    topics =
+        platform.upload.advisor
+        platform.upload.testareno
+    """
+    try:
+        sh.rm(file_path)
+    except Exception:
+        pass
+
+    with open(file_path, "w") as fp:
+        fp.write(body)
+
+    os.environ['TOPIC_CONFIG'] = '/tmp/topics.ini'
+
+    import app
+
+    return app
+
+
+app = prepare_app()
 
 
 @pytest.fixture()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,6 +2,7 @@ import asyncio
 import io
 import json
 import os
+import sh
 
 import pytest
 import requests
@@ -21,6 +22,10 @@ from mock import patch
 client = AsyncHTTPClient()
 with open('VERSION', 'rb') as f:
     VERSION = f.readlines()[0]
+
+
+def cleanup():
+    sh.rm(app.TOPIC_CONFIG)
 
 
 class TestContentRegex(TestCase):
@@ -166,6 +171,21 @@ class TestUploadHandler(AsyncHTTPTestCase):
 
         self.assertEqual(response.exception.code, 415)
         self.assertEqual(response.exception.message, 'Upload field not found')
+
+    @gen_test
+    def test_upload_post_unsupported_mime_type(self):
+        request_context = self.prepare_request_context(file_name='payload.tar.gz', mime_type='application/vnd.redhat.boop.something+tgz')
+
+        with self.assertRaises(HTTPClientError) as response:
+            yield self.http_client.fetch(
+                self.get_url('/r/insights/platform/upload/api/v1/upload'),
+                method='POST',
+                body=request_context.body,
+                headers=request_context.headers
+            )
+
+        self.assertEqual(response.exception.code, 415)
+        self.assertEqual(response.exception.message, 'Unsupported MIME type')
 
 
 class TestProducerAndConsumer:
@@ -353,3 +373,6 @@ class TestProducerAndConsumer:
             assert mq.disconnect_in_operation_called is True
             assert mq.trying_to_connect_failures_calls == 1
             assert len(app.produce_queue) == 4
+
+
+cleanup()


### PR DESCRIPTION
Currently, if a message comes in with a topic we don't support, it gets stuck in the queue and will repeatedly fail forever. One of the ways to handle it is to maintain a valid topic list. This PR implements that idea. 

There is also the possibility that we throw an error if we get a bad one, but a user could think that their payload succeeded (they get a 200) and it really just gets dropped. 

This solution will send a 415 error so they know that it's a mime type we don't support. Since our mime type equates to a topic, this might be the way to go. Open to suggestions on it. 

I took a stab at writing a test for it. There is also already a configMap in openshift CI project wiht the topics that we use, so if this gets merged everything should be peachy. 