### PR TITLE
Add support to run linters with tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.tox
 .pytest_cache
 .vscode
 *.pyc

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,5 @@
+- project:
+    check:
+      jobs:
+        - tox-linters:
+            nodeset: fedora-latest-1vcpu

--- a/spec.yaml
+++ b/spec.yaml
@@ -7,7 +7,7 @@ info:
   version: 0.0.1
   title: Upload Service
   contact:
-    email: sadams@redhat.com
+      email: sadams@redhat.com
 
 paths:
   /:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+flake8
+yamllint

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+minversion = 1.6
+skipsdist = True
+envlist = linters
+
+[testenv]
+install_command = pip install {opts} {packages}
+deps = -r{toxinidir}/test-requirements.txt
+
+[testenv:linters]
+commands =
+  yamllint .
+  flake8 {posargs}
+
+[testenv:venv]
+commands = {posargs}
+
+[flake8]
+# These are ignored intentionally;
+# please don't submit patches that solely correct them or enable them.
+ignore = E125,E129,H
+show-source = True
+exclude = .venv,.tox,dist,doc,build,*.egg


### PR DESCRIPTION
Tox is a generic virtualenv management and test command line tool. This
quickly allows for users to run testing locally via a single entry
point. As an example, we'll be adding flake8 and yamllint testing using
tox -elinters

Signed-off-by: Paul Belanger <pabelanger@redhat.com>