### PR TITLE
Check that full dir path exists in localdisk write()

### DIFF
--- a/utils/storage/localdisk.py
+++ b/utils/storage/localdisk.py
@@ -16,9 +16,10 @@ def stage():
 
 
 def write(data, dest, uuid):
-    if not os.path.isdir(WORKDIR):
+    dir_path = os.path.join(WORKDIR, dest)
+    if dir_path in dirs and not os.path.isdir(dir_path):
         stage()
-    with open(os.path.join(WORKDIR, dest, uuid), 'w') as f:
+    with open(os.path.join(dir_path, uuid), 'w') as f:
         f.write(data)
         url = f
     return url.name


### PR DESCRIPTION
This check fails if "/tmp/uploads" is mounted in OpenShift since the WORKDIR already exists but the child directories do not.