### PR TITLE
Get version data at launch

### DIFF
--- a/app.py
+++ b/app.py
@@ -119,6 +119,9 @@ def get_commit_date(url):
         return date
 
 
+BUILD_DATE = get_commit_date("https://api.github.com/repos/RedHatInsights/insights-upload/git/commits/" + BUILD_ID)
+
+
 def split_content(content):
     """Split the content_type to find the service name
 
@@ -482,9 +485,8 @@ class VersionHandler(tornado.web.RequestHandler):
     def get(self):
         """Handle GET request to the `version` endpoint
         """
-        url = "https://api.github.com/repos/RedHatInsights/insights-upload/git/commits/" + BUILD_ID
         response = {'commit': BUILD_ID,
-                    'date': get_commit_date(url)}
+                    'date': BUILD_DATE}
         self.write(response)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ def prepare_app():
         fp.write(body)
 
     os.environ['TOPIC_CONFIG'] = '/tmp/topics.json'
+    os.environ['OPENSHIFT_BUILD_COMMIT'] = 'f06bfd06040103caae5fde96b9f4c8be7f4d979a'
 
     import app
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -114,7 +114,6 @@ class TestUploadHandler(AsyncHTTPTestCase):
 
         self.assertEqual(response.code, 202)
 
-    @patch('app.BUILD_ID', 'f06bfd06040103caae5fde96b9f4c8be7f4d979a')
     @gen_test
     def test_version(self):
         response = yield self.http_client.fetch(self.get_url('/r/insights/platform/upload/api/v1/version'), method='GET')


### PR DESCRIPTION
Change to grabbing version date at launch rather than when querying
the version endpoint. This is a faster way to handle it rather than
hitting github with each request