### PR TITLE
Fix a bug related to regex check

### DIFF
--- a/app.py
+++ b/app.py
@@ -309,8 +309,11 @@ class UploadHandler(tornado.web.RequestHandler):
             mnm.uploads_unsupported_filetype.inc()
             logger.error("Unsupported Media Type: [%s] - Request-ID [%s]", self.payload_data['content_type'], self.payload_id)
             return self.error(415, 'Unsupported Media Type')
-        if not DEVMODE and re.search(content_regex, self.payload_data['content_type']).group(1) not in VALID_TOPICS:
-            logger.error("Unsupported MIME type: [%s] - Request-ID [%s]", self.payload_data['content_type'], self.payload_id)
+        if re.search(content_regex, self.payload_data['content_type']):
+            if not DEVMODE and re.search(content_regex, self.payload_data['content_type']).group(1) not in VALID_TOPICS:
+                logger.error("Unsupported MIME type: [%s] - Request-ID [%s]", self.payload_data['content_type'], self.payload_id)
+                return self.error(415, 'Unsupported MIME type')
+        else:
             return self.error(415, 'Unsupported MIME type')
 
     def get(self):


### PR DESCRIPTION
If regex wasn't matched, we proceeded anyway when not using DEVMODE. This resulted in a NoneType error and a payload getting stuck in the produce queue