### PR TITLE
Set up openapi spec endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,9 @@ from utils import mnm
 from logstash_formatter import LogstashFormatterV1
 from prometheus_async.aio import time as prom_time
 
+from apispec import APISpec
+from apispec_webframeworks.tornado import TornadoPlugin
+
 # Logging
 LOGLEVEL = os.getenv("LOGLEVEL", "INFO")
 if any("KUBERNETES" in k for k in os.environ):
@@ -112,6 +115,22 @@ produce_queue = collections.deque([], 999)
 
 # Executor used to run non-async/blocking tasks
 thread_pool_executor = ThreadPoolExecutor(max_workers=MAX_WORKERS)
+
+# Set up ApiSpec object
+spec = APISpec(
+    title='Insights Upload Service',
+    version='0.0.1',
+    openapi_version='3.0.0',
+    info=dict(
+        description='A service designed to ingest payloads from customers and distribute them via message queue to other platform services.',
+        contact=dict(
+            email='sadams@redhat.com'
+        )
+    ),
+    plugins=[
+        TornadoPlugin()
+    ]
+)
 
 
 def get_commit_date(commit_id):
@@ -287,16 +306,36 @@ class NoAccessLog(tornado.web.RequestHandler):
 
 
 class RootHandler(NoAccessLog):
-    """Handles requests to root
+    """Handles requests to document root
     """
 
     def get(self):
         """Handle GET requests to the root url
+        ---
+        description: Used for OpenShift Liveliness probes
+        responses:
+            200:
+                description: OK
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+                            example: boop
         """
         self.write("boop")
 
     def options(self):
         """Return a header containing the available methods
+        ---
+        description: Add a header containing allowed methods
+        responses:
+            200:
+                description: OK
+                headers:
+                    Allow:
+                        description: Allowed methods
+                        schema:
+                            type: string
         """
         self.add_header('Allow', 'GET, HEAD, OPTIONS')
 
@@ -326,6 +365,16 @@ class UploadHandler(tornado.web.RequestHandler):
 
     def get(self):
         """Handles GET requests to the upload endpoint
+        ---
+        description: Get accepted content types
+        responses:
+            200:
+                description: OK
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+                            example: 'Accepted Content-Types: gzipped tarfile, zip file'
         """
         self.write("Accepted Content-Types: gzipped tarfile, zip file")
 
@@ -445,6 +494,15 @@ class UploadHandler(tornado.web.RequestHandler):
 
         Validate upload, get service name, create UUID, save to local storage,
         then offload for async processing
+        ---
+        description: Process Insights archive
+        responses:
+            202:
+                description: Upload payload accepted
+            413:
+                description: Payload too large
+            415:
+                description: Upload field not found
         """
         mnm.uploads_total.inc()
         self.identity = None
@@ -486,6 +544,16 @@ class UploadHandler(tornado.web.RequestHandler):
 
     def options(self):
         """Handle OPTIONS request to upload endpoint
+        ---
+        description: Add a header containing allowed methods
+        responses:
+            200:
+                description: OK
+                headers:
+                    Allow:
+                        description: Allowed methods
+                        schema:
+                            type: string
         """
         self.add_header('Allow', 'GET, POST, HEAD, OPTIONS')
 
@@ -496,6 +564,22 @@ class VersionHandler(tornado.web.RequestHandler):
 
     def get(self):
         """Handle GET request to the `version` endpoint
+        ---
+        description: Get version identifying information
+        responses:
+            200:
+                description: OK
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                commit:
+                                    type: string
+                                    example: ab3a3a90b48bb1101a287b754d33ac3b2316fdf2
+                                date:
+                                    type: string
+                                    example: '2019-03-19T14:17:27Z'
         """
         response = {'commit': BUILD_ID,
                     'date': BUILD_DATE}
@@ -507,15 +591,44 @@ class MetricsHandler(NoAccessLog):
     """
 
     def get(self):
+        """Get metrics for upload service
+        ---
+        description: Get metrics for upload service
+        responses:
+            200:
+                description: OK
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+        """
         self.write(mnm.generate_latest())
 
+class SpecHandler(tornado.web.RequestHandler):
+    """Handle requests for service's API Spec
+    """
+
+    def get(self):
+        """Get the openapi/swagger spec for the upload service
+        ---
+        description: Get openapi spec for upload service
+        responses:
+            200:
+                description: OK
+        """
+        response = spec.to_dict()
+        self.write(json.dumps(response))
 
 endpoints = [
     (r"/r/insights/platform/upload", RootHandler),
     (r"/r/insights/platform/upload/api/v1/version", VersionHandler),
     (r"/r/insights/platform/upload/api/v1/upload", UploadHandler),
+    (r"/r/insights/platform/upload/api/v1/openapi.json", SpecHandler),
     (r"/metrics", MetricsHandler)
 ]
+
+for urlSpec in endpoints:
+    spec.path(urlspec=urlSpec)
 
 app = tornado.web.Application(endpoints, max_body_size=MAX_LENGTH)
 

--- a/app.py
+++ b/app.py
@@ -617,6 +617,7 @@ class MetricsHandler(NoAccessLog):
         """
         self.write(mnm.generate_latest())
 
+
 class SpecHandler(tornado.web.RequestHandler):
     """Handle requests for service's API Spec
     """
@@ -631,6 +632,7 @@ class SpecHandler(tornado.web.RequestHandler):
         """
         response = spec.to_dict()
         self.write(json.dumps(response))
+
 
 endpoints = [
     (r"/r/insights/platform/upload", RootHandler),

--- a/app.py
+++ b/app.py
@@ -631,7 +631,7 @@ class SpecHandler(tornado.web.RequestHandler):
                 description: OK
         """
         response = spec.to_dict()
-        self.write(json.dumps(response))
+        self.write(response)
 
 
 endpoints = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 aiokafka==0.4.3
+apispec==1.1.0
+apispec-webframeworks==0.3.0
 asn1crypto==0.24.0
 astroid==2.0.4
 atomicwrites==1.2.1


### PR DESCRIPTION
Adds openapi 3.0 spec generation and serves out generated spec via /api/v1/openapi.json