### PR TITLE
Pass the x-rh-insights-request-id along to the inventory service

### DIFF
--- a/app.py
+++ b/app.py
@@ -264,7 +264,10 @@ async def handle_file(msgs):
 
 
 def post_to_inventory(identity, payload_id, values):
-    headers = {'x-rh-identity': identity, 'Content-Type': 'application/json'}
+    headers = {'x-rh-identity': identity,
+               'Content-Type': 'application/json',
+               'x-rh-insights-request-id': payload_id,
+               }
     post = strip_empty_facts(values['metadata'])
     post['account'] = values['account']
     try:


### PR DESCRIPTION
I think the upload-service needs to pass the x-rh-insights-request-id header along to the inventory service.

@SteveHNH I did not test this as I didn't have time to setup the upload-service locally, etc.  Feel free to throw this away and fix it how you like.  This is really just a placeholder for an idea.