### PR TITLE
Support connections to our old endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -652,6 +652,10 @@ endpoints = [
     (API_PREFIX + "/v1/version", VersionHandler),
     (API_PREFIX + "/v1/upload", UploadHandler),
     (API_PREFIX + "/v1/openapi.json", SpecHandler),
+    (r"/r/insights/platform/upload", RootHandler),
+    (r"/r/insights/platform/upload/api/v1/version", VersionHandler),
+    (r"/r/insights/platform/upload/api/v1/upload", UploadHandler),
+    (r"/r/insights/platform/upload/api/v1/openapi.json", SpecHandler),
     (r"/metrics", MetricsHandler)
 ]
 


### PR DESCRIPTION
It turns out that we need to keep the old URL endpoints in due to satellite support