### PR TITLE
Add metadata to fileobj

### DIFF
--- a/app.py
+++ b/app.py
@@ -452,8 +452,11 @@ class UploadHandler(tornado.web.RequestHandler):
         upload_start = time()
         logger.info("tracking id [%s] payload_id [%s] attempting upload", tracking_id, payload_id, extra={"request_id": payload_id})
 
+        account = self.identity.get("account_number")
+        user_agent = self.request.headers.get("User-Agent")
         try:
-            url = await defer(storage.write, filename, storage.PERM, payload_id)
+            url = await defer(storage.write, filename, storage.PERM, payload_id,
+                              account, user_agent)
             elapsed = time() - upload_start
 
             logger.info(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,7 +178,9 @@ def broker_stage_messages(s3_mocked, produce_queue_mocked):
         file_path = s3_storage.write(
             _file,
             s3_storage.PERM,
-            file_name
+            file_name,
+            app.DUMMY_VALUES['account'],
+            'curl/7.61.1'
         )
 
         values = {

--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -9,6 +9,7 @@ import pytest
 import responses
 from botocore.exceptions import ClientError
 
+import app
 from utils import mnm
 from utils.storage import localdisk as local_storage, s3 as s3_storage
 
@@ -30,7 +31,9 @@ class TestS3(object):
         url = s3_storage.write(
             local_file,
             s3_storage.PERM,
-            key_name
+            key_name,
+            app.DUMMY_VALUES['account'],
+            'curl/7.61.1'
         )
 
         assert url is not None
@@ -43,7 +46,9 @@ class TestS3(object):
         write_file_path = s3_storage.write(
             local_file,
             s3_storage.PERM,
-            key_name
+            key_name,
+            app.DUMMY_VALUES['account'],
+            'curl/7.61.1'
         )
         copy_file_path = s3_storage.copy(s3_storage.PERM, s3_storage.REJECT, key_name)
 
@@ -65,7 +70,9 @@ class TestS3(object):
         file_url = s3_storage.write(
             local_file,
             s3_storage.PERM,
-            key_name
+            key_name,
+            app.DUMMY_VALUES['account'],
+            'curl/7.61.1'
         )
 
         ls_response = s3_storage.ls(s3_storage.PERM, key_name)

--- a/utils/storage/s3.py
+++ b/utils/storage/s3.py
@@ -23,8 +23,10 @@ s3 = boto3.client('s3',
 
 
 @mnm.uploads_s3_write_seconds.time()
-def write(data, dest, uuid):
-    s3.upload_file(data, dest, uuid)
+def write(data, dest, uuid, account, user_agent):
+    s3.upload_file(data, dest, uuid, ExtraArgs={"Metadata": {"account": account,
+                                                             "user-agent": user_agent}
+                                                })
     url = s3.generate_presigned_url('get_object',
                                     Params={'Bucket': dest,
                                             'Key': uuid}, ExpiresIn=86400)


### PR DESCRIPTION
We want to collect certain data related to an individual object. Starting with account number and user agent, but more fields can be added in the future as we determine that we need them. 