### PR TITLE
Set up a metric to track upload field names

### DIFF
--- a/app.py
+++ b/app.py
@@ -517,7 +517,11 @@ class UploadHandler(tornado.web.RequestHandler):
                 **extra
             )
 
-        # TODO: pull this out once no one is using the upload field anymore
+        try:
+            upload_field = list(self.request.files)[0]
+            mnm.uploads_file_field.labels(field=upload_field).inc()
+        except IndexError:
+            pass
         self.payload_data = self.request.files.get('upload')[0] if self.request.files.get('upload') else self.request.files.get('file')[0]
 
         if self.payload_id is None:

--- a/utils/mnm.py
+++ b/utils/mnm.py
@@ -23,6 +23,7 @@ uploads_unsupported_filetype = Counter('uploads_unsupported_filetype', 'The tota
 uploads_handed_off = Counter('uploads_handed_off', 'The total number of uploads handed off')
 uploads_produced_to_topic = Counter('uploads_produced_to_queue', 'Total number of messages pushed to the produce_queue for given topic.', ['topic'])
 uploads_popped_to_topic = Counter('uploads_popped_to_queue', 'Total number of messages popped from the produce_queue for given topic.', ['topic'])
+uploads_file_field = Counter('uploads_file_field', 'Total number of payloads recieved using which form field', ['field'])
 
 # Prometheus Summaries
 uploads_write_tarfile = Summary('uploads_write_tarfile_seconds', 'Total seconds it takes to write the tarfile upon upload')


### PR DESCRIPTION
This is a metric to try to understand how many uploads we have coming in
using the old `upload` field name. Once this hits 0 over time, we can
remove the ability to post with this field name