### PR TITLE
Adding topics.json to allow upload-service to start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.6
+COPY ./topics.json /tmp
 WORKDIR /usr/src/app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt

--- a/topics.json
+++ b/topics.json
@@ -1,0 +1,11 @@
+ 
+ [
+	{ "TOPIC_NAME":"platform.upload.advisor" },
+	{ "TOPIC_NAME":"platform.upload.testareno" },
+	{ "TOPIC_NAME":"platform.upload.validation" },
+	{ "TOPIC_NAME":"platform.upload.available" },
+	{ "TOPIC_NAME":"platform.upload.hccm" },
+	{ "TOPIC_NAME":"platform.upload.compliance" },
+	{ "TOPIC_NAME":"platform.upload.qpc" }
+ ]
+


### PR DESCRIPTION
After trying to run the service the upload-service container was complaining because it didn't find /tmp/topics.json
I have created one with the values in the README.md
