### PR TITLE
Rename payload_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,14 @@ queue.
 
 The message from the upload service is JSON as seen below:
 
-    {'account': '123456', 'rh_account': '123456', 'principal': 'test_org', 'payload_id': '52df9f748eabcfea', 'hash': '52df9f748eabcfea', 'size': 356, 'service': 'testareno', 'b64_identity': '<identity header base64 string>', 'metadata': {'some_key': 'some_value', 'some_other_key': 'some_other_value'}, 'url': '/tmp/uploads/insights-upload-quarantine/52df9f748eabcfea'}
+    {'account': '123456', 'rh_account': '123456', 'principal': 'test_org', 'request_id': '52df9f748eabcfea', 'size': 356, 'service': 'testareno', 'b64_identity': '<identity header base64 string>', 'metadata': {'some_key': 'some_value', 'some_other_key': 'some_other_value'}, 'url': '/tmp/uploads/insights-upload-quarantine/52df9f748eabcfea'}
 
 Fields:
 
   - account: The account number used to upload. Can be used to separate data for tenancy purposes.
   - rh_account: legacy support for the above value. To be deprecated
   - principal:  The uploading org id
-  - payload_id: Unique ID provided to the payload created by 3Scale. This ID will be used for the life of the object.
-  - hash:       Legacy key name. Provides the same UID as payload_id. Will be deprecated.
+  - request_id: Unique ID provided to the payload created by 3Scale. This ID will be used for the life of the object.
   - size:       Size of the payload in bytes
   - service:    The name of the service to do the validation
   - b64_identity: The base64 string from `x-rh-identity` header
@@ -56,7 +55,7 @@ Fields:
   - url:        URL for the location the payload can be downloaded from
 
 Principal is currently reflecting the org_id of the account, though that may change
-as we understand what is most useful regarding who uploaded a particular archive. The payload_id
+as we understand what is most useful regarding who uploaded a particular archive. The request_id
 is a unique ID assigned to the uploaded file by the 3Scale gateway. Everything else
 is fairly self-explanatory.
 
@@ -64,11 +63,11 @@ Service should return most of the same data that was received with the addition 
 
 This is what a message with **minimum** required data should look like:
 
-    {'payload_id': '52df9f748eabcfea', 'service': 'advisor', 'validation': 'success'} # or 'validation': 'failure'
+    {'request_id': '52df9f748eabcfea', 'service': 'advisor', 'validation': 'success'} # or 'validation': 'failure'
 
 Fields:
 
-  - payload_id: Unique ID being addresed by validation message
+  - request_id: Unique ID being addresed by validation message
   - service: The service that performed the validation
   - validation: Either succes or failure based on whether the payload passed validation or not
 

--- a/app.py
+++ b/app.py
@@ -367,7 +367,7 @@ class UploadHandler(tornado.web.RequestHandler):
             logger.exception("Unsupported Media Type: [%s] - Request-ID [%s]", self.payload_data['content_type'], self.request_id, extra=extra)
             return self.error(415, 'Unsupported Media Type', **extra)
         if serv_dict["service"] not in self.valid_topics:
-            logger.error("Unsupported MIME type: [%s] - Request-ID [%s]", self.payload_data['content_type'], self.payload_id, extra=extra)
+            logger.error("Unsupported MIME type: [%s] - Request-ID [%s]", self.payload_data['content_type'], self.request_id, extra=extra)
             return self.error(415, 'Unsupported MIME type', **extra)
 
     def get(self):

--- a/app.py
+++ b/app.py
@@ -171,15 +171,15 @@ def make_preprocessor(queue=None):
     queue = produce_queue if queue is None else queue
 
     @prom_time(mnm.uploads_send_and_wait_seconds)
-    async def send(client, topic, data, extra, payload_id, item, msg):
+    async def send(client, topic, data, extra, request_id, item, msg):
         try:
             await client.send_and_wait(topic, data.encode("utf-8"))
         except KafkaError:
             queue.append(item)
-            current_archives.append(payload_id)
+            current_archives.append(request_id)
             logger.error(
-                "send data for topic [%s] with payload_id [%s] failed, put back on queue (qsize now: %d)",
-                topic, payload_id, len(queue), extra=extra)
+                "send data for topic [%s] with request_id [%s] failed, put back on queue (qsize now: %d)",
+                topic, request_id, len(queue), extra=extra)
             raise
         except Exception:
             logger.exception("Failure to send_and_wait. Did *not* put item back on queue.",
@@ -200,17 +200,17 @@ def make_preprocessor(queue=None):
 
             async def _work(item):
                 try:
-                    topic, msg, payload_id = item['topic'], item['msg'], item['msg'].get('payload_id')
+                    topic, msg, request_id = item['topic'], item['msg'], item['msg'].get('request_id')
                     extra["account"] = msg["account"]
-                    extra["request_id"] = payload_id
+                    extra["request_id"] = request_id
                     mnm.uploads_popped_to_topic.labels(topic=topic).inc()
                 except Exception:
                     logger.exception("Bad data from produce_queue.", extra={"item": item, **extra})
                     return
 
                 logger.info(
-                    "Popped data from produce queue (qsize now: %d) for topic [%s], payload_id [%s]",
-                    len(queue), topic, payload_id, extra=extra)
+                    "Popped data from produce queue (qsize now: %d) for topic [%s], request_id [%s]",
+                    len(queue), topic, request_id, extra=extra)
 
                 try:
                     with mnm.uploads_json_dumps.labels(key="send_to_preprocessors").time():
@@ -220,7 +220,7 @@ def make_preprocessor(queue=None):
                                      extra={"queue_msg": msg, **extra})
                     return
 
-                await send(client, topic, data, extra, payload_id, item, msg)
+                await send(client, topic, data, extra, request_id, item, msg)
 
             await asyncio.gather(*[asyncio.ensure_future(_work(item)) for item in items])
 
@@ -247,17 +247,16 @@ async def handle_file(msg):
         logger.error("handle_file(): unable to decode msg as json", extra=extra)
         return
 
-    if 'payload_id' not in data and 'hash' not in data:
-        logger.error("payload_id or hash not in message. Payload not removed from permanent.", extra=extra)
+    if 'request_id' not in data and 'hash' not in data:
+        logger.error("request_id or hash not in message. Payload not removed from permanent.", extra=extra)
         return
 
-    # get the payload_id. Getting the hash is temporary until consumers update
-    payload_id = data['payload_id'] if 'payload_id' in data else data.get('hash')
-    extra["request_id"] = payload_id
+    request_id = data['request_id']
+    extra["request_id"] = request_id
     extra["account"] = account = data.get('account', 'unknown')
     result = data.get('validation', 'unknown')
 
-    logger.info('processing message: payload [%s] - %s', payload_id, result, extra=extra)
+    logger.info('processing message: payload [%s] - %s', request_id, result, extra=extra)
 
     if result.lower() == 'success':
         mnm.uploads_validated.inc()
@@ -266,9 +265,9 @@ async def handle_file(msg):
                 'topic': 'platform.upload.available',
                 'msg': {
                     'id': data.get('id'),
-                    'url': await defer(storage.get_url, storage.PERM, payload_id),
+                    'url': await defer(storage.get_url, storage.PERM, request_id),
                     'service': data.get('service'),
-                    'payload_id': payload_id,
+                    'request_id': request_id,
                     'account': account,
                     'principal': data.get('principal'),
                     'b64_identity': data.get('b64_identity'),
@@ -279,23 +278,23 @@ async def handle_file(msg):
             }
             mnm.uploads_produced_to_topic.labels(topic="platform.upload.available").inc()
             produce_queue.append(data)
-            current_archives.append(payload_id)
+            current_archives.append(request_id)
             logger.info(
-                "data for topic [%s], payload_id [%s], inv_id [%s] put on produce queue (qsize now: %d)",
-                data['topic'], payload_id, data["msg"].get("id"), len(produce_queue), extra=extra)
-            logger.debug("payload_id [%s] data: {}".format(data), payload_id, extra=extra)
+                "data for topic [%s], request_id [%s], inv_id [%s] put on produce queue (qsize now: %d)",
+                data['topic'], request_id, data["msg"].get("id"), len(produce_queue), extra=extra)
+            logger.debug("request_id [%s] data: {}".format(data), request_id, extra=extra)
         except Exception:
             logger.exception("Failure while handling success.", extra=extra)
     elif result.lower() == 'failure':
         mnm.uploads_invalidated.inc()
-        logger.info('payload_id [%s] rejected', payload_id, extra=extra)
+        logger.info('request_id [%s] rejected', request_id, extra=extra)
         try:
-            await defer(storage.copy, storage.PERM, storage.REJECT, payload_id, account)
+            await defer(storage.copy, storage.PERM, storage.REJECT, request_id, account)
         except Exception:
             logger.exception("Failure while handling failure (aw shucks).", extra=extra)
     elif result.lower() == 'handoff':
         mnm.uploads_handed_off.inc()
-        logger.info('payload_id [%s] handed off', payload_id, extra=extra)
+        logger.info('request_id [%s] handed off', request_id, extra=extra)
     else:
         logger.info('Unrecognized result: %s', result.lower(), extra=extra)
 
@@ -357,20 +356,20 @@ class UploadHandler(tornado.web.RequestHandler):
         Returns:
             tuple -- status code and a user friendly message
         """
-        extra = get_extra(account=self.account, request_id=self.payload_id)
+        extra = get_extra(account=self.account, request_id=self.request_id)
         content_length = int(self.request.headers["Content-Length"])
         if content_length >= config.MAX_LENGTH:
             mnm.uploads_too_large.inc()
-            logger.error("Payload too large. Request ID [%s] - Length %s", self.payload_id, str(config.MAX_LENGTH), extra=extra)
+            logger.error("Payload too large. Request ID [%s] - Length %s", self.request_id, str(config.MAX_LENGTH), extra=extra)
             return self.error(413, f"Payload too large: {content_length}. Should not exceed {config.MAX_LENGTH} bytes", **extra)
         try:
             serv_dict = get_service(self.payload_data['content_type'])
         except Exception:
             mnm.uploads_unsupported_filetype.inc()
-            logger.exception("Unsupported Media Type: [%s] - Request-ID [%s]", self.payload_data['content_type'], self.payload_id, extra=extra)
+            logger.exception("Unsupported Media Type: [%s] - Request-ID [%s]", self.payload_data['content_type'], self.request_id, extra=extra)
             return self.error(415, 'Unsupported Media Type', **extra)
         if not config.DEVMODE and serv_dict["service"] not in VALID_TOPICS:
-            logger.error("Unsupported MIME type: [%s] - Request-ID [%s]", self.payload_data['content_type'], self.payload_id, extra=extra)
+            logger.error("Unsupported MIME type: [%s] - Request-ID [%s]", self.payload_data['content_type'], self.request_id, extra=extra)
             return self.error(415, 'Unsupported MIME type', **extra)
 
     def get(self):
@@ -388,7 +387,7 @@ class UploadHandler(tornado.web.RequestHandler):
         """
         self.write("Accepted Content-Types: gzipped tarfile, zip file")
 
-    async def upload(self, data, payload_id, identity):
+    async def upload(self, data, request_id, identity):
         """Write the payload to the configured storage
 
         Storage write and os file operations are not async so we offload to executor.
@@ -396,30 +395,30 @@ class UploadHandler(tornado.web.RequestHandler):
         Arguments:
             filename {str} -- The filename to upload. Should be the tmpfile
                               created by `write_data`
-            payload_id {str} -- the unique ID for this upload generated by 3Scale at time of POST
+            request_id {str} -- the unique ID for this upload generated by 3Scale at time of POST
 
         Returns:
             str -- URL of uploaded file if successful
             None if upload failed
         """
         user_agent = self.request.headers.get("User-Agent")
-        extra = get_extra(account=self.account, request_id=payload_id)
+        extra = get_extra(account=self.account, request_id=request_id)
 
         upload_start = time()
         try:
-            url = await defer(storage.write, data, storage.PERM, payload_id, self.account, user_agent)
+            url = await defer(storage.write, data, storage.PERM, request_id, self.account, user_agent)
             elapsed = time() - upload_start
 
             logger.info(
-                "payload_id [%s] uploaded! elapsed [%fsec] url [%s]",
-                payload_id, elapsed, url, extra=extra)
+                "request_id [%s] uploaded! elapsed [%fsec] url [%s]",
+                request_id, elapsed, url, extra=extra)
 
             return url
         except Exception:
             elapsed = time() - upload_start
             logger.exception(
-                "Exception hit uploading: payload_id [%s] elapsed [%fsec]",
-                payload_id, elapsed, extra=extra)
+                "Exception hit uploading: request_id [%s] elapsed [%fsec]",
+                request_id, elapsed, extra=extra)
 
     async def process_upload(self):
         """Process the uploaded file we have received.
@@ -428,13 +427,13 @@ class UploadHandler(tornado.web.RequestHandler):
             filename {str} -- The filename to upload. Should be the tmpfile
                               created by `write_data`
             size {int} -- content-length of the uploaded filename
-            payload_id {str} -- the unique ID for this upload generated by 3Scale at time of POST
+            request_id {str} -- the unique ID for this upload generated by 3Scale at time of POST
             identity {str} -- identity pulled from request headers (if present)
             service {str} -- The service this upload is intended for
 
         Write to storage, send message to MQ
         """
-        extra = get_extra(account=self.account, request_id=self.payload_id)
+        extra = get_extra(account=self.account, request_id=self.request_id)
         values = {}
         # use dummy values for now if no account given
         if self.identity:
@@ -444,8 +443,7 @@ class UploadHandler(tornado.web.RequestHandler):
         else:
             values['account'] = config.DUMMY_VALUES['account']
             values['principal'] = config.DUMMY_VALUES['principal']
-        values['payload_id'] = self.payload_id
-        values['hash'] = self.payload_id  # provided for backward compatibility
+        values['request_id'] = self.request_id
         values['size'] = self.size
         values['service'] = self.service
         values['category'] = self.category
@@ -454,17 +452,17 @@ class UploadHandler(tornado.web.RequestHandler):
             with mnm.uploads_json_loads.labels(key="process_upload").time():
                 values['metadata'] = clean_up_metadata(json.loads(self.metadata))
 
-        url = await self.upload(self.filedata, self.payload_id, self.identity)
+        url = await self.upload(self.filedata, self.request_id, self.identity)
 
         if url:
             values['url'] = url
             topic = 'platform.upload.' + self.service
             mnm.uploads_produced_to_topic.labels(topic=topic).inc()
-            current_archives.append(self.payload_id)
+            current_archives.append(self.request_id)
             produce_queue.append({'topic': topic, 'msg': values})
             logger.info(
-                "Data for payload_id [%s] to topic [%s] put on produce queue (qsize now: %d)",
-                self.payload_id, topic, len(produce_queue), extra=extra
+                "Data for request_id [%s] to topic [%s] put on produce queue (qsize now: %d)",
+                self.request_id, topic, len(produce_queue), extra=extra
             )
 
     @mnm.uploads_write_tarfile.time()
@@ -510,7 +508,7 @@ class UploadHandler(tornado.web.RequestHandler):
                 description: Upload field not found
         """
         mnm.uploads_total.inc()
-        self.payload_id = self.request.headers.get('x-rh-insights-request-id', uuid.uuid4().hex)
+        self.request_id = self.request.headers.get('x-rh-insights-request-id', uuid.uuid4().hex)
         self.account = "unknown"
 
         # is this really ok to be optional?
@@ -521,7 +519,7 @@ class UploadHandler(tornado.web.RequestHandler):
             self.identity = header['identity']
             self.account = self.identity["account_number"]
 
-        extra = get_extra(account=self.account, request_id=self.payload_id)
+        extra = get_extra(account=self.account, request_id=self.request_id)
 
         if not self.request.files.get('upload') and not self.request.files.get('file'):
             return self.error(
@@ -538,8 +536,8 @@ class UploadHandler(tornado.web.RequestHandler):
             pass
         self.payload_data = self.request.files.get('upload')[0] if self.request.files.get('upload') else self.request.files.get('file')[0]
 
-        if self.payload_id is None:
-            return self.error(400, "No payload_id assigned.  Upload failed.", **extra)
+        if self.request_id is None:
+            return self.error(400, "No request_id assigned.  Upload failed.", **extra)
 
         if self.upload_validation():
             mnm.uploads_invalid.inc()

--- a/app.py
+++ b/app.py
@@ -268,6 +268,7 @@ async def handle_file(msg):
                     'url': await defer(storage.get_url, storage.PERM, request_id),
                     'service': data.get('service'),
                     'request_id': request_id,
+                    'payload_id': request_id,
                     'account': account,
                     'principal': data.get('principal'),
                     'b64_identity': data.get('b64_identity'),
@@ -444,6 +445,7 @@ class UploadHandler(tornado.web.RequestHandler):
             values['account'] = config.DUMMY_VALUES['account']
             values['principal'] = config.DUMMY_VALUES['principal']
         values['request_id'] = self.request_id
+        values['payload_id'] = self.request_id
         values['size'] = self.size
         values['service'] = self.service
         values['category'] = self.category

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,7 +174,7 @@ def broker_stage_messages(s3_mocked, produce_queue_mocked):
             'account': config.DUMMY_VALUES['account'],
             'principal': config.DUMMY_VALUES['principal'],
             'validation': validation,
-            'payload_id': file_name,
+            'request_id': file_name,
             'size': 100,
             'service': service,
             'url': file_path

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -234,7 +234,7 @@ class TestProducerAndConsumer:
                 produced_messages.append(message)
 
             for m in produced_messages:
-                assert s3_storage.ls(s3_storage.PERM, m['payload_id'])['ResponseMetadata']['HTTPStatusCode'] == 200
+                assert s3_storage.ls(s3_storage.PERM, m['request_id'])['ResponseMetadata']['HTTPStatusCode'] == 200
 
             assert mq.produce_calls_count == total_messages
             assert mq.count_topic_messages(topic) == total_messages
@@ -244,7 +244,7 @@ class TestProducerAndConsumer:
             event_loop.run_until_complete(self.coroutine_test(consumer))
 
             for m in produced_messages:
-                assert s3_storage.ls(s3_storage.PERM, m['payload_id'])['ResponseMetadata']['HTTPStatusCode'] == 200
+                assert s3_storage.ls(s3_storage.PERM, m['request_id'])['ResponseMetadata']['HTTPStatusCode'] == 200
 
             assert mq.consume_calls_count > 0
             assert mq.consume_return_messages_count == 1
@@ -279,8 +279,8 @@ class TestProducerAndConsumer:
             event_loop.run_until_complete(self.coroutine_test(consumer))
 
             for m in produced_messages:
-                assert s3_storage.ls(s3_storage.PERM, m['payload_id'])['ResponseMetadata']['HTTPStatusCode'] == 404
-                assert s3_storage.ls(s3_storage.REJECT, m['payload_id'])['ResponseMetadata']['HTTPStatusCode'] == 200
+                assert s3_storage.ls(s3_storage.PERM, m['request_id'])['ResponseMetadata']['HTTPStatusCode'] == 404
+                assert s3_storage.ls(s3_storage.REJECT, m['request_id'])['ResponseMetadata']['HTTPStatusCode'] == 200
 
             assert mq.consume_calls_count > 0
             assert mq.consume_return_messages_count == 1


### PR DESCRIPTION
Resolving some tech debt we've had for a while. `payload_id` should be renamed to `request_id` in order to keep some consistency throughout the platform for what an individual archive is called and tracked by. 

This is a big one because it will effect everyone who reads from the message queue and needs this ID. Just getting this initial work out here. 

Don't merge this until we have things communicated. Might be worth other apps to just implement this update while continuing to support the old one so we can phase it out without any major interruptions.