### PR TITLE
Make the log_group configurable by ENV

### DIFF
--- a/app.py
+++ b/app.py
@@ -77,7 +77,7 @@ if (config.CW_AWS_ACCESS_KEY_ID and config.CW_AWS_SECRET_ACCESS_KEY):
                          aws_secret_access_key=config.CW_AWS_SECRET_ACCESS_KEY,
                          region_name=config.CW_AWS_REGION_NAME)
     cw_handler = watchtower.CloudWatchLogHandler(boto3_session=CW_SESSION,
-                                                 log_group="platform",
+                                                 log_group=config.LOG_GROUP,
                                                  stream_name=NAMESPACE)
     cw_handler.setFormatter(LogstashFormatterV1())
     logger.addHandler(cw_handler)

--- a/utils/config.py
+++ b/utils/config.py
@@ -42,6 +42,8 @@ BUILD_ID = os.getenv('OPENSHIFT_BUILD_COMMIT', '8d06f664a88253c361e61af5a4fa2ac5
 TOPIC_CONFIG = os.getenv('TOPIC_CONFIG', '/tmp/topics.json')
 MAX_RECORDS = int(os.getenv("MAX_RECORDS", 1))
 
+LOG_GROUP = os.getenv("LOG_GROUP", "platform")
+
 # Items in this map are _special cases_ where the service cannot be extracted
 # from the Content-Type
 SERVICE_MAP = {


### PR DESCRIPTION
In the event that the log group changes for cloudwatch, we should be
able to modify it easily without going back to the source.