### PR TITLE
Add 1 second sleep before creating buckets

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - minio
     entrypoint: >
       /bin/sh -c "
+      /bin/sleep 1;
       /usr/bin/mc config host add myminio http://minio:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY;
       /usr/bin/mc mb myminio/insights-upload-perm-test;
       /usr/bin/mc mb myminio/insights-upload-quarantine;


### PR DESCRIPTION
"docker_upload-service_1" is not yet properly started before creating buckets and we get: 
"connect: connection refused"